### PR TITLE
update data fetch code to wait 2 seconds

### DIFF
--- a/src/components/NewTask.tsx
+++ b/src/components/NewTask.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef } from "react";
-// import { useEffect } from "react";
 import { Box, Button, TextField } from "@mui/material";
 import type { NewTaskProps, InputChangeEvent } from "../types";
 import AddTaskIcon from "@mui/icons-material/AddTask";
@@ -25,16 +24,6 @@ export default function NewTask({ addTask, boardType }: NewTaskProps) {
       didJustAddTask.current = true;
     }
   };
-
-  // useEffect(() => {
-  //   if (didJustAddTask.current) {
-  //     window.scrollTo({
-  //       top: document.body.scrollHeight,
-  //       behavior: "smooth",
-  //     });
-  //     didJustAddTask.current = false;
-  //   }
-  // }, []);
 
   return (
     <Box className="pt-3 w-full bg-gray-100 flex justify-center items-center">

--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -1,29 +1,39 @@
 import Task from "./Task";
 import { Box } from "@mui/material";
 import type { TaskBoardProps } from "../types";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function TaskBoard({
   tasks,
   deleteTask,
   updateTaskValue,
   updateTaskStatus,
+  endRef,
 }: TaskBoardProps) {
-  const endRef = useRef<HTMLDivElement | null>(null);
-  const prevTaskCountRef = useRef<number>(tasks.length);
+  // const endRef = useRef<HTMLDivElement | null>(null);
+  // const prevTaskCountRef = useRef<number>(tasks.length);
+  // const mountCount = useRef(0);
 
-  // const bottomFade =
-  // ("[-webkit-mask-image:linear-gradient(180deg,#000_60%,transparent)]");
+  // const [canScroll, setCanScroll] = useState(false);
 
-  useEffect(() => {
-    if (tasks.length > prevTaskCountRef.current) {
-      // Only scroll if a task was added
-      endRef.current?.scrollIntoView({ behavior: "smooth" });
-    }
+  // // useEffect(() => {
+  // //   mountCount.current += 1;
+  // //   console.log(`internal ${mountCount.current} time(s)`);
+  // // }, [tasks.length]);
 
-    // Update previous task count for next comparison
-    prevTaskCountRef.current = tasks.length;
-  }, [tasks.length]);
+  // useEffect(() => {
+  //   if (tasks.length > prevTaskCountRef.current && canScroll) {
+  //     // Only scroll if a task was added
+  //     // endRef.current?.scrollIntoView({ behavior: "smooth" });
+  //   }
+
+  //   // Update previous task count for next comparison
+  //   prevTaskCountRef.current = tasks.length;
+  // }, [tasks.length]);
+
+  // useEffect(() => {
+  //   setCanScroll(true);
+  // }, []);
 
   return (
     <>
@@ -40,7 +50,8 @@ export default function TaskBoard({
             updateTaskStatus={updateTaskStatus}
           />
         ))}
-        <div ref={endRef} /> {/* Scroll target */}
+        <div ref={endRef} />
+        {/* Scroll target */}
       </Box>
     </>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,7 @@ export type TaskBoardProps = {
     boardType: boardType
   ) => void;
   boardType: boardType;
+  endRef?: React.RefObject<HTMLDivElement>; // 👈 Add this
 };
 
 export type Task = {


### PR DESCRIPTION
- updated code in MainBoard to make localStorage data fetch wait 2 seconds, to give Firestore data fetch requests time to return user data
- in the case of localStorage and Firestore data having different orders for the tasks, this will solves screen flickering issue where tasks seem to jump around on first load
- removed unused comments