### PR TITLE
fixed Task vertical centering issue, created new BoardToggle component

### DIFF
--- a/src/components/BoardToggle.tsx
+++ b/src/components/BoardToggle.tsx
@@ -1,0 +1,31 @@
+import { Box, Button } from "@mui/material";
+import type { boardType } from "../types";
+
+export interface BoardToggleProps {
+  activeBoard: boardType;
+  onBoardChange: (board: boardType) => void;
+}
+
+export default function BoardToggle({
+  activeBoard,
+  onBoardChange,
+}: BoardToggleProps) {
+  return (
+    <Box className="z-100 bg-gray-100 p-5 text-center gap-2 bottom-0 flex justify-center">
+      <Button
+        size="large"
+        variant={activeBoard === "todo" ? "contained" : "outlined"}
+        onClick={() => onBoardChange("todo")}
+      >
+        To Do
+      </Button>
+      <Button
+        size="large"
+        variant={activeBoard === "done" ? "contained" : "outlined"}
+        onClick={() => onBoardChange("done")}
+      >
+        Done
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/MainBoard.tsx
+++ b/src/components/MainBoard.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import TaskBoard from "./TaskBoard";
-import { Box, Button } from "@mui/material";
+import SignIn from "./SignIn";
+import NewTask from "./NewTask";
+import BoardToggle from "./BoardToggle";
+import { Box } from "@mui/material";
 import { v4 as uuidv4 } from "uuid";
 import type { Task, boardType } from "../types";
 import Slide from "@mui/material/Slide";
-import NewTask from "./NewTask";
-import SignIn from "./SignIn";
 import {
   auth,
   provider,
@@ -397,30 +398,16 @@ export default function MainBoard() {
           </Box>
 
           <Box className="bg-gray-100 fixed mt-5 bottom-5 w-full h-[100px]">
-            <Box className="fade-container"></Box>
             <Box
               className={`bottom-gradient ${
                 hideGradient ? "hide-gradient" : ""
               }`}
             />
-
             <NewTask addTask={addTask} boardType={activeBoard} />
-            <Box className="z-100 bg-gray-100 p-5 text-center gap-2 bottom-0 flex justify-center">
-              <Button
-                size="large"
-                variant={activeBoard === "todo" ? "contained" : "outlined"}
-                onClick={() => handleBoardChange("todo")}
-              >
-                To Do
-              </Button>
-              <Button
-                size="large"
-                variant={activeBoard === "done" ? "contained" : "outlined"}
-                onClick={() => handleBoardChange("done")}
-              >
-                Done
-              </Button>
-            </Box>
+            <BoardToggle
+              activeBoard={activeBoard}
+              onBoardChange={handleBoardChange}
+            />
           </Box>
         </Box>
       </Box>

--- a/src/components/NewTask.tsx
+++ b/src/components/NewTask.tsx
@@ -13,6 +13,7 @@ export default function NewTask({ addTask, boardType }: NewTaskProps) {
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
+      e.preventDefault();
       handleAddTask();
     }
   };
@@ -27,23 +28,23 @@ export default function NewTask({ addTask, boardType }: NewTaskProps) {
 
   return (
     <Box className=" pt-3 w-full bg-gray-100 flex justify-center items-center">
-        <TextField
-          className="w-[55%] ml-[32px]"
-          multiline
-          variant="standard"
-          placeholder="Add task"
-          value={newTask}
-          onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
-        />
+      <TextField
+        className="w-[55%] ml-[32px]"
+        multiline
+        variant="standard"
+        placeholder="Add task"
+        value={newTask}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+      />
 
-        <Button
-          className="ml-[5px] h-8 w-8 min-w-0 rounded-full"
-          variant="contained"
-          onClick={handleAddTask}
-        >
-          <AddTaskIcon className="h-5"/>
-        </Button>
+      <Button
+        className="ml-[5px] h-8 w-8 min-w-0 rounded-full"
+        variant="contained"
+        onClick={handleAddTask}
+      >
+        <AddTaskIcon className="h-5" />
+      </Button>
     </Box>
   );
 }

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -100,14 +100,14 @@ function TaskInput(
   return (
     <>
       <TextField
-        className="max-w-80 flex-2 p-0"
+        className="max-w-80 flex-1"
         variant="standard"
         value={taskValue}
         onChange={handleInputChange}
         multiline
-        inputProps={{
-          className: "m-0 p-0", // or "text-right", etc.
-        }}
+        // inputProps={{
+        //   className: "m-0 p-0", // or "text-right", etc.
+        // }}
 
         // style={{ margin: "10px 0" }}
       />


### PR DESCRIPTION
- users can create a new task by pressing Enter (or Return on mobile), but with the NewTask component now having multiline, the key press to submit the task _also_ adds a new line to the NewTask textfield. using preventDefault fixed this issue
- moved code from MainBoard to BoardToggle
- deleted unneeded fade-container in MainBoard